### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ datapacker (1.0.4) UNRELEASED; urgency=medium
     + Build-Depends: Drop versioned constraint on ghc, haskell-devscripts and
       libghc-missingh-dev.
   * Bump debhelper from old 12 to 13.
+  * Add missing debian/rules targets build-indep, build-arch.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 12 Oct 2021 12:26:01 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ datapacker (1.0.4) UNRELEASED; urgency=medium
       libghc-missingh-dev.
   * Bump debhelper from old 12 to 13.
   * Add missing debian/rules targets build-indep, build-arch.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 12 Oct 2021 12:26:01 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ datapacker (1.0.4) UNRELEASED; urgency=medium
   * Remove constraints unnecessary since buster:
     + Build-Depends: Drop versioned constraint on ghc, haskell-devscripts and
       libghc-missingh-dev.
+  * Bump debhelper from old 12 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 12 Oct 2021 12:26:01 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 13), groff, docbook-utils, man-db, ghostscrip
  ghc, haskell-devscripts, libghc-missingh-dev,
  libghc-unix-dev, libghc-mtl-dev, libghc-filepath-dev, libghc-hslogger-dev
 Build-Conflicts: docbook-ebnf
-Standards-Version: 4.5.1
+Standards-Version: 4.6.1
 Homepage: https://github.com/jgoerzen/datapacker/wiki
 Vcs-Browser: https://github.com/jgoerzen/datapacker
 Vcs-Git: https://github.com/jgoerzen/datapacker.git

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: datapacker
 Section: utils
 Priority: optional
 Maintainer: John Goerzen <jgoerzen@complete.org>
-Build-Depends: debhelper-compat (= 12), groff, docbook-utils, man-db, ghostscript,
+Build-Depends: debhelper-compat (= 13), groff, docbook-utils, man-db, ghostscript,
  gtk-doc-tools, sgml2x,
  ghc, haskell-devscripts, libghc-missingh-dev,
  libghc-unix-dev, libghc-mtl-dev, libghc-filepath-dev, libghc-hslogger-dev

--- a/debian/rules
+++ b/debian/rules
@@ -89,4 +89,8 @@ binary-arch: build install
 	dh_builddeb
 
 binary: binary-indep binary-arch
-.PHONY: build clean binary-indep binary-arch binary install configure
+.PHONY: build clean binary-indep binary-arch binary install configure build-indep build-arch
+
+build-indep:
+
+build-arch: build


### PR DESCRIPTION
Fix some issues reported by lintian

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Add missing debian/rules targets build-indep, build-arch. ([debian-rules-missing-recommended-target](https://lintian.debian.org/tags/debian-rules-missing-recommended-target))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/datapacker/7b59b947-4156-4764-b503-0d8b5956b8fb.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/0b/62a0c0a47a37361546efe89471af151c95c3ce.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3c/a41d715940a14f9ed38837183b7f8d693224b0.debug
### Control files of package datapacker: lines which differ (wdiff format)
* Depends: libc6 (>= [-2.29),-] {+2.34),+} libffi8 (>= 3.4), libgmp10 (>= [-2:6.2.1+dfsg)-] {+2:6.2.1+dfsg1)+}
### Control files of package datapacker-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-3ca41d715940a14f9ed38837183b7f8d693224b0-] {+0b62a0c0a47a37361546efe89471af151c95c3ce+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7b59b947-4156-4764-b503-0d8b5956b8fb/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7b59b947-4156-4764-b503-0d8b5956b8fb/diffoscope)).
